### PR TITLE
Removing references to siraj material

### DIFF
--- a/week3-classification-regression/README.md
+++ b/week3-classification-regression/README.md
@@ -50,7 +50,6 @@
 * While most regression problems can be solved using statistics, for example with a method known as "ordinary least squares", in the case or large data sets with many input variables, the equation cannot easily be estimated in one fell swoop. This is where the machine learning technique known as "gradient descent" comes in. Gradient descent is an algorithmic process which adjusts the parameters of a model according to errors to minimize errors. Performed iteratively overtime, a linear or polynomial regression equation can be estimated. This technique will serve as a fundamental piece of building a neural network simulation and so while it is unnecessary in the simple linear regression examples for this week, it's the perfect place to learn and practice the algorithm.
 * [Rebecca Fiebrink's Machine Learning for Musicians and Artists Session 2](https://www.kadenze.com/courses/machine-learning-for-musicians-and-artists-v/sessions/regression)
 * [Chapter 3 of An Introduction to Statistical Learning (ISL)](http://www-bcf.usc.edu/~gareth/ISL/)
-* [Linear Regression with Gradient Descent video tutorial from Siraj](https://www.youtube.com/watch?v=XdM6ER7zTLk)
 * [Week 1 of Andrew Ng's Machine Learning Coursera course](https://www.coursera.org/learn/machine-learning/home/week/1)
 * [Tom Alexander's JS Regression Library](https://github.com/Tom-Alexander/regression-js)
 * A video [tutorial](https://www.youtube.com/watch?v=HJRWhgyjoNo&t=608s) of the math and implementation by Jyo Pari

--- a/week6-rnn-tensorflow/README.md
+++ b/week6-rnn-tensorflow/README.md
@@ -14,7 +14,6 @@
 * [Tomas Mikolov's Thesis](http://www.fit.vutbr.cz/~imikolov/rnnlm/thesis.pdf)
 * [LSTM Networks for Sentiment Analysis](http://deeplearning.net/tutorial/lstm.html)
 * [Recurrent Neural Networks in Tensorflow](https://www.tensorflow.org/versions/r0.10/tutorials/recurrent/)
-* [Siraj's RNN video](https://www.youtube.com/watch?v=cdLUzrjnlr4), [code on github](https://github.com/llSourcell/recurrent_neural_net_demo/blob/master/rnn.py)
 
 ### Other projects and resources
 * [Writing with the Machine](https://www.robinsloan.com/notes/writing-with-the-machine/)

--- a/week6bonus-reinforcement-neuroevolution/README.md
+++ b/week6bonus-reinforcement-neuroevolution/README.md
@@ -32,5 +32,4 @@ Augmenting Topologies](http://nn.cs.utexas.edu/downloads/papers/stanley.ec02.pdf
 
 ## Examples / Tutorials
 * [Reinforcement Q-Learning Tutorial](https://github.com/Hvass-Labs/TensorFlow-Tutorials/blob/master/16_Reinforcement_Learning.ipynb)
-* Siraj's [How to Beat Pong Using Policy Gradients](https://www.youtube.com/watch?v=PDbXPBwOavc) video. [code](https://github.com/llSourcell/Policy_Gradients_to_beat_Pong) (Using OpenAI Universe)
 * Udacity's [Q Learning example](https://github.com/udacity/deep-learning/blob/master/reinforcement/Q-learning-cart.ipynb) (uses OpenAI gym)


### PR DESCRIPTION
These references are being removed related to the recent discovery of plagiarism on Siraj's channel. This follows a pattern of little to no crediting of sources in code examples and videos.

For more background:
https://twitter.com/AndrewM_Webb/status/1183150368945049605

I don't feel I can confidently sent viewers in the direction of his content at this time. I would be happy to reconsider if and when it becomes appropriate to do so in the future. 

😞 